### PR TITLE
Add the windows subsystem app

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --all-features --verbose
 
       - name: Run tests
         run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,16 @@ regex = "1.11.1"
 simplelog = "0.12.2"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+
+[features]
+default = []
+winapp = []
+
+[[bin]]
+name = "monitor-input"
+path = "src/main.rs"
+
+[[bin]]
+name = "monitor-inputw"
+required-features = ["winapp"]
+path = "src/main_winapp.rs"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ Also exposed [as library](#as-library).
 cargo install monitor-input
 ```
 
+## Windows App
+
+On Windows, there are two types of applications:
+console applications and Windows applications.
+The `monitor-input` is a console application.
+This means that,
+if you run it from non-console applications,
+a console window pops up.
+
+To run it from non-console applications
+without seeing the console window popping up,
+a Windows subsystem version is available as an optional feature.
+Please add `-F winapp` to the `cargo install` command.
+```shell-session
+cargo install monitor-input -F winapp
+```
+The `-F winapp` option installs
+the `monitor-inputw.exe` (note the `w` suffix)
+in addition to the `monitor-input.exe`.
+The executable with the `w` suffix is a Windows subsystem application.
+
 ## From [github](https://github.com/kojiishi/monitor-input-rs)
 
 ```shell-session

--- a/src/main_winapp.rs
+++ b/src/main_winapp.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(feature = "winapp", windows_subsystem = "windows")]
+
+use clap::Parser;
+use monitor_input::{Cli, Monitor};
+
+fn main() -> anyhow::Result<()> {
+    let mut cli: Cli = Cli::parse();
+    cli.init_logger();
+    cli.monitors = Monitor::enumerate();
+    cli.run()
+}


### PR DESCRIPTION
The `monitor-inputw` is the windows subsystem app, while `monitor-input` is the console app.
