### PR TITLE
Switch to `env_logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +371,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "libc"
@@ -440,6 +487,7 @@ dependencies = [
  "anyhow",
  "clap",
  "ddc-hi",
+ "env_logger",
  "log",
  "mccs-db",
  "regex",
@@ -505,6 +553,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-run = "monitor-input"
 anyhow = "1.0.97"
 clap = { version = "4.5.38", features = ["derive"] }
 ddc-hi = "0.4.1"
+env_logger = { version = "0.11.8", optional = true }
 log = "0.4.26"
 mccs-db = "0.1.3"
 regex = "1.11.1"
@@ -25,7 +26,7 @@ strum_macros = "0.27.1"
 
 [features]
 default = ["console"]
-console = []
+console = ["dep:env_logger"]
 winapp = []
 
 [[bin]]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ impl Cli {
 
     /// Initialize the logging.
     /// The configurations depend on [`Cli::verbose`].
+    #[deprecated(
+        since = "1.2.1",
+        note = "To remove loggers from the lib. Please setup your favorite logger."
+    )]
     pub fn init_logger(&self) {
         simplelog::CombinedLogger::init(vec![simplelog::TermLogger::new(
             match self.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,37 @@
+use std::env;
+use std::io::Write;
+
 use clap::Parser;
+
 use monitor_input::{Cli, Monitor};
 
 fn main() -> anyhow::Result<()> {
     let mut cli: Cli = Cli::parse();
-    cli.init_logger();
+    init_logger(cli.verbose);
     cli.monitors = Monitor::enumerate();
     cli.run()
+}
+
+fn init_logger(verbose: u8) {
+    // If `RUST_LOG` is set, initialize the `env_logger` in its default config.
+    if env::var("RUST_LOG").is_ok() {
+        env_logger::init();
+        return;
+    }
+
+    // Otherwise setup according to the `verbose` level, in a simpler format.
+    env_logger::Builder::new()
+        .filter_level(match verbose {
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        })
+        .format(|buf, record| match record.level() {
+            log::Level::Info => writeln!(buf, "{}", record.args()),
+            _ => {
+                let style = buf.default_level_style(record.level());
+                writeln!(buf, "{style}{}{style:#}: {}", record.level(), record.args())
+            }
+        })
+        .init();
 }

--- a/src/main_winapp.rs
+++ b/src/main_winapp.rs
@@ -5,7 +5,6 @@ use monitor_input::{Cli, Monitor};
 
 fn main() -> anyhow::Result<()> {
     let mut cli: Cli = Cli::parse();
-    cli.init_logger();
     cli.monitors = Monitor::enumerate();
     cli.run()
 }


### PR DESCRIPTION
To ease logging and debugging. The `-v` option still works, in
addition to the `RUST_LOG` environment variable.

The `Cli::init_logger` is deprecated and will be removed soon
to remove dependencies to loggers from the library code.
