### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -223,7 +223,7 @@ dependencies = [
  "ddc",
  "io-kit-sys",
  "mach2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "monitor-input"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -732,7 +732,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -740,6 +749,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -781,12 +801,13 @@ dependencies = [
 
 [[package]]
 name = "toast-logger-win"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81770b0b6a524b2d3fec59dd0cf077fd14cf4935ca53486383c0a9951536339"
+checksum = "54f42b0679c1d7906e5af75b74648a1ad2956e9020c3c13df3cbf557a469da26"
 dependencies = [
  "anyhow",
  "log",
+ "thiserror 2.0.12",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitor-input"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2024"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "A command line tool to change input sources of display monitors with DDC/CI."
@@ -23,7 +23,7 @@ regex = "1.11.1"
 simplelog = "0.12.2"
 strum = "0.27.1"
 strum_macros = "0.27.1"
-toast-logger-win = { version = "0.4.0", optional = true }
+toast-logger-win = { version = "0.5.0", optional = true }
 
 [features]
 default = ["console"]

--- a/src/main_winapp.rs
+++ b/src/main_winapp.rs
@@ -12,7 +12,8 @@ fn main() -> anyhow::Result<()> {
     init_logger(cli.verbose);
     cli.monitors = Monitor::enumerate();
     cli.run()?;
-    ToastLogger::flush()
+    ToastLogger::flush()?;
+    Ok(())
 }
 
 fn init_logger(verbose: u8) {


### PR DESCRIPTION
Includes `toast-logger-win` from 0.4.0 to 0.5.0.
